### PR TITLE
Add simple error solution

### DIFF
--- a/src/errors/errors.js
+++ b/src/errors/errors.js
@@ -1,0 +1,16 @@
+/**
+ * Simple method to return a formatted error object.
+ * Can be refactored at a later date to be a class
+ * which extends Error if needed, whose constructor
+ * will accept a message string.
+ * TODO: Generic error code constants.
+ * @param {string} message Description of the error
+ */
+
+export default function errorObject(message) {
+  return {
+    success: 'false',
+    message,
+    code: message,
+  };
+}


### PR DESCRIPTION
Fixes #32 

Added a simple error solution which can be refactored if necessary. 

Not sure if we need generic error code constants? EG AUTH_ERROR etc.

Example:

```
  try {
      methodWhichThrowsAnError()
    } catch (e) {
      throw errorObject('Error occured!');
    }
  }
```

Can still be tested, although a little annoying:

```
test('should throw an error', () => {
  let errorCatcher;
  try {
    methodToTest();
  } catch (e) {
    errorCatcher = e;
  }
 expect(errorCatcher).toEqual(errorObject('Error'));
});
```

