### PR TITLE
#18 login method

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,4 @@
 {
-  "presets": [["@babel/preset-env", { "shippedProposals": true }]]
+  "presets": [["@babel/preset-env", { "shippedProposals": true }]],
+  "plugins": ["@babel/plugin-proposal-class-properties"]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -113,6 +113,19 @@
         "@babel/types": "^7.0.0"
       }
     },
+    "@babel/helper-create-class-features-plugin": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.3.2.tgz",
+      "integrity": "sha512-tdW8+V8ceh2US4GsYdNVNoohq5uVwOf9k6krjwW4E1lINcHgttnWcNqgdoessn12dAy8QkbezlbQh2nXISNY+A==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-function-name": "^7.1.0",
+        "@babel/helper-member-expression-to-functions": "^7.0.0",
+        "@babel/helper-optimise-call-expression": "^7.0.0",
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/helper-replace-supers": "^7.2.3"
+      }
+    },
     "@babel/helper-define-map": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.1.0.tgz",
@@ -325,6 +338,16 @@
         "@babel/helper-plugin-utils": "^7.0.0",
         "@babel/helper-remap-async-to-generator": "^7.1.0",
         "@babel/plugin-syntax-async-generators": "^7.2.0"
+      }
+    },
+    "@babel/plugin-proposal-class-properties": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.3.0.tgz",
+      "integrity": "sha512-wNHxLkEKTQ2ay0tnsam2z7fGZUi+05ziDJflEt3AZTP3oXLKHJp9HqhfroB/vdMvt3sda9fAbq7FsG8QPDrZBg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-create-class-features-plugin": "^7.3.0",
+        "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
     "@babel/plugin-proposal-json-strings": {
@@ -5927,10 +5950,9 @@
       "dev": true
     },
     "qs": {
-      "version": "6.5.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
-      "dev": true
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.6.0.tgz",
+      "integrity": "sha512-KIJqT9jQJDQx5h5uAVPimw6yVg2SekOKu959OCtktD3FjzbpvaPr8i4zzg07DOMz+igA4W/aNM7OV8H37pFYfA=="
     },
     "read-pkg": {
       "version": "2.0.0",
@@ -6187,6 +6209,12 @@
           "version": "1.4.1",
           "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
           "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+          "dev": true
+        },
+        "qs": {
+          "version": "6.5.2",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+          "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
           "dev": true
         },
         "tough-cookie": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -709,7 +709,6 @@
       "version": "7.2.5",
       "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.2.5.tgz",
       "integrity": "sha512-8Y/t3MWThtMLYr0YNC/Q76tqN1w30+b0uQMeFUYauG2UGTR19zyUtFrAzT23zNtBxPp+LbE5E/nwV/q/r3y6ug==",
-      "dev": true,
       "requires": {
         "core-js": "^2.5.7",
         "regenerator-runtime": "^0.12.0"
@@ -1826,8 +1825,7 @@
     "core-js": {
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.3.tgz",
-      "integrity": "sha512-l00tmFFZOBHtYhN4Cz7k32VM7vTn3rE2ANjQDxdEN6zmXZ/xq1jQuutnmHvMG1ZJ7xd72+TA5YpUK8wz3rWsfQ==",
-      "dev": true
+      "integrity": "sha512-l00tmFFZOBHtYhN4Cz7k32VM7vTn3rE2ANjQDxdEN6zmXZ/xq1jQuutnmHvMG1ZJ7xd72+TA5YpUK8wz3rWsfQ=="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -6074,8 +6072,7 @@
     "regenerator-runtime": {
       "version": "0.12.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
-      "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg==",
-      "dev": true
+      "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg=="
     },
     "regenerator-transform": {
       "version": "0.13.3",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "prettier": "1.16.4"
   },
   "dependencies": {
+    "@babel/polyfill": "^7.2.5",
     "axios": "^0.18.0",
     "qs": "^6.6.0"
   }

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@babel/cli": "^7.2.3",
     "@babel/core": "^7.2.2",
     "@babel/node": "^7.2.2",
+    "@babel/plugin-proposal-class-properties": "^7.3.0",
     "@babel/preset-env": "^7.3.1",
     "eslint": "^5.3.0",
     "eslint-config-airbnb": "^17.1.0",
@@ -54,6 +55,7 @@
     "prettier": "1.16.4"
   },
   "dependencies": {
-    "axios": "^0.18.0"
+    "axios": "^0.18.0",
+    "qs": "^6.6.0"
   }
 }

--- a/src/api/ApiConfigs.js
+++ b/src/api/ApiConfigs.js
@@ -9,7 +9,7 @@ export default class ApiConfigs {
   static cookie = '';
 
   static BASE_CONFIG = {
-    baseURL: 'http://127.0.0.1:9921',
+    baseURL: 'https://83.96.240.209',
     httpsAgent: new https.Agent({
       rejectUnauthorized: false,
     }),
@@ -21,7 +21,7 @@ export default class ApiConfigs {
 
   static getLoginConfig = (username, password) => ({
     ...ApiConfigs.BASE_CONFIG,
-    url: '/cookie',
+    url: '/j_spring_security_check',
     withCredentials: true,
     headers: { 'content-type': 'application/x-www-form-urlencoded' },
     data: qs.stringify({ j_username: username, j_password: password }),

--- a/src/api/ApiConfigs.js
+++ b/src/api/ApiConfigs.js
@@ -1,0 +1,29 @@
+import qs from 'qs';
+import https from 'https';
+
+/**
+ * Static class for managing Axios configurations of eSigl API
+ * requests.
+ */
+export default class ApiConfigs {
+  static cookie = '';
+
+  static BASE_CONFIG = {
+    baseURL: 'http://127.0.0.1:9921',
+    httpsAgent: new https.Agent({
+      rejectUnauthorized: false,
+    }),
+  };
+
+  static setCookie = cookie => {
+    ApiConfigs.cookie = cookie;
+  };
+
+  static getLoginConfig = (username, password) => ({
+    ...ApiConfigs.BASE_CONFIG,
+    url: '/cookie',
+    withCredentials: true,
+    headers: { 'content-type': 'application/x-www-form-urlencoded' },
+    data: qs.stringify({ j_username: username, j_password: password }),
+  });
+}

--- a/src/api/ApiConfigs.js
+++ b/src/api/ApiConfigs.js
@@ -25,5 +25,7 @@ export default class ApiConfigs {
     withCredentials: true,
     headers: { 'content-type': 'application/x-www-form-urlencoded' },
     data: qs.stringify({ j_username: username, j_password: password }),
+    validateStatus: status => (status >= 200 && status < 300) || status === 302,
+    maxRedirects: 0,
   });
 }

--- a/src/api/ApiConfigs.js
+++ b/src/api/ApiConfigs.js
@@ -8,6 +8,11 @@ import https from 'https';
 export default class ApiConfigs {
   static cookie = '';
 
+  // TODO: Solution for enterable URLS.
+  // Option: set URL method, similar to how cookies work.
+  // This needs to be done BEFORE MERGING INTO MASTER,
+  // however will keep like this for nwo as development
+  // is easier.
   static BASE_CONFIG = {
     baseURL: 'https://83.96.240.209',
     httpsAgent: new https.Agent({

--- a/src/errors/errors.js
+++ b/src/errors/errors.js
@@ -1,3 +1,8 @@
+export const ERROR_LOGIN = method => `${method} Error: Incorrect username or password`;
+export const ERROR_SERVER = method => `${method} Error: Unknown Server Error`;
+export const ERROR_UNKNOWN = method => `${method} Error: Unknown status code error (Not: 401, 500)`;
+export const ERROR_REQUEST = method => `${method} Error: Request malformed`;
+export const ERROR_COOKIE = method => `${method} Error: Unable to set session cookie`;
 /**
  * Simple method to return a formatted error object.
  * Can be refactored at a later date to be a class
@@ -6,11 +11,10 @@
  * TODO: Generic error code constants.
  * @param {string} message Description of the error
  */
-
-export default function errorObject(message) {
+export function errorObject(ERROR_CODE, method) {
   return {
     success: 'false',
-    message,
-    code: message,
+    message: ERROR_CODE(method),
+    code: ERROR_CODE.name,
   };
 }

--- a/src/errors/errors.js
+++ b/src/errors/errors.js
@@ -1,3 +1,12 @@
+/**
+ * Methods whose name corresponds to Error Codes.
+ * Each method returns a more specific error
+ * message indicating exactly where the error
+ * occurred. Potentially need to add a second
+ * paremeter for the exact code block the error
+ * occured.
+ */
+
 export const ERROR_LOGIN = method => `${method} Error: Incorrect username or password`;
 export const ERROR_SERVER = method => `${method} Error: Unknown Server Error`;
 export const ERROR_UNKNOWN = method => `${method} Error: Unknown status code error (Not: 401, 500)`;
@@ -10,9 +19,8 @@ export const ERROR_VALIDATION = (method, block) => {
 /**
  * Simple method to return a formatted error object.
  * Can be refactored at a later date to be a class
- * which extends Error if needed, whose constructor
- * will accept a message string.
- * TODO: Generic error code constants.
+ * which extends Error if needed.
+ * TODO: Specific error code constants.
  * @param {string} message Description of the error
  */
 export function errorObject(ERROR_CODE, method, block) {

--- a/src/errors/errors.js
+++ b/src/errors/errors.js
@@ -3,6 +3,10 @@ export const ERROR_SERVER = method => `${method} Error: Unknown Server Error`;
 export const ERROR_UNKNOWN = method => `${method} Error: Unknown status code error (Not: 401, 500)`;
 export const ERROR_REQUEST = method => `${method} Error: Request malformed`;
 export const ERROR_COOKIE = method => `${method} Error: Unable to set session cookie`;
+export const ERROR_VALIDATION = (method, block) => {
+  return `${method} Error: Malformed input during ${block} check`;
+};
+
 /**
  * Simple method to return a formatted error object.
  * Can be refactored at a later date to be a class
@@ -11,10 +15,10 @@ export const ERROR_COOKIE = method => `${method} Error: Unable to set session co
  * TODO: Generic error code constants.
  * @param {string} message Description of the error
  */
-export function errorObject(ERROR_CODE, method) {
+export function errorObject(ERROR_CODE, method, block) {
   return {
     success: 'false',
-    message: ERROR_CODE(method),
+    message: ERROR_CODE(method, block),
     code: ERROR_CODE.name,
   };
 }

--- a/src/requests.js
+++ b/src/requests.js
@@ -9,12 +9,27 @@ import {
   ERROR_COOKIE,
 } from './errors/errors';
 
+/**
+ * Method which will return a valid authentication cookie for eSigl.
+ * Returned with the name=value pair JSESSIONID=XXXX.
+ * eSigl will attempt to redirect after a succesful POST, returning
+ * the login page HTML. The axios login config limits redirects to 0,
+ * causing the response status 302, which has been set as a valid response
+ * code.
+ * Errors: Errors will be thrown within the try by either JS or Axios. An axios
+ * error will have a response or request property (or both). If an error is
+ * thrown with a response property, the request has returned from the server,
+ * but has an invalid status code. Without a response property, the request
+ * has failed to reach the server. With neither, the request has not been set at all.
+ * @param {string} username
+ * @param {string} password
+ */
+
 export default async function login(username, password) {
   const config = ApiConfigs.getLoginConfig(username, password);
   try {
     const { headers } = await axios(config);
-    const cookie = headers['set-cooie'][0];
-    ApiConfigs.setCookie(cookie);
+    return headers['set-cookie'][0].split(';')[0];
   } catch (error) {
     const { response } = error;
     const { request } = error;

--- a/src/requests.js
+++ b/src/requests.js
@@ -19,11 +19,13 @@ import {
  * code.
  * Errors: Errors will be thrown within the try by either JS or Axios. An axios
  * error will have a response or request property (or both). If an error is
- * thrown with a response property, the request has returned from the server,
+ * thrown with a response property, the request has returned from the server
  * but has an invalid status code. Without a response property, the request
  * has failed to reach the server. With neither, the request has not been set at all.
- * @param {string} username
- * @param {string} password
+ *
+ * @param  {string} username eSigl username in plain text
+ * @param  {string} password Corresponding eSigl password in plain text
+ * @return {string} Valid eSigl JSession cookie
  */
 
 export async function login(username, password) {

--- a/src/requests.js
+++ b/src/requests.js
@@ -1,0 +1,30 @@
+import axios from 'axios';
+import ApiConfigs from './api/ApiConfigs';
+import {
+  errorObject,
+  ERROR_LOGIN,
+  ERROR_SERVER,
+  ERROR_UNKNOWN,
+  ERROR_REQUEST,
+  ERROR_COOKIE,
+} from './errors/errors';
+
+export default async function login(username, password) {
+  const config = ApiConfigs.getLoginConfig(username, password);
+  try {
+    const { headers } = await axios(config);
+    const cookie = headers['set-cooie'][0];
+    ApiConfigs.setCookie(cookie);
+  } catch (error) {
+    const { response } = error;
+    const { request } = error;
+    if (response) {
+      const { status } = response;
+      if (status === 401) throw errorObject(ERROR_LOGIN, 'Login');
+      if (status === 500) throw errorObject(ERROR_SERVER, 'Login');
+      throw errorObject(ERROR_UNKNOWN, 'Login');
+    }
+    if (request) throw errorObject(ERROR_REQUEST, 'Login');
+    throw errorObject(ERROR_COOKIE, 'Login');
+  }
+}

--- a/src/requests.js
+++ b/src/requests.js
@@ -1,3 +1,4 @@
+/* eslint-disable import/prefer-default-export */
 import axios from 'axios';
 import ApiConfigs from './api/ApiConfigs';
 import {
@@ -25,7 +26,7 @@ import {
  * @param {string} password
  */
 
-export default async function login(username, password) {
+export async function login(username, password) {
   const config = ApiConfigs.getLoginConfig(username, password);
   try {
     const { headers } = await axios(config);

--- a/src/tests/apiConfigs.test.js
+++ b/src/tests/apiConfigs.test.js
@@ -1,0 +1,19 @@
+import ApiConfigs from '../api/ApiConfigs';
+
+test('Cookie should be set.', () => {
+  const value = 'TestCookie';
+  ApiConfigs.setCookie(value);
+  expect(ApiConfigs.cookie).toBe(value);
+});
+
+test('Login config fields should be equal', () => {
+  const config = ApiConfigs.getLoginConfig('user123', 'password123');
+  // This should only be enabled during testing of OpenStack VM.
+  // expect(config.httpsAgent.options.rejectUnauthorized).toBe(false);
+  expect(config.maxRedirects).toBe(0);
+  expect(config.headers).toEqual({
+    'content-type': 'application/x-www-form-urlencoded',
+  });
+  expect(config.data).toBe('j_username=user123&j_password=password123');
+  expect(config.url).toBe('/j_spring_security_check');
+});

--- a/src/tests/requests/login.test.js
+++ b/src/tests/requests/login.test.js
@@ -1,6 +1,8 @@
+// TODO: Add this to ESLint config if they occur
+// more then this file, eg in other tests.
 /* eslint-disable global-require */
-
 /* eslint-disable no-throw-literal */
+
 import '@babel/polyfill';
 import {
   errorObject,

--- a/src/tests/requests/login.test.js
+++ b/src/tests/requests/login.test.js
@@ -1,0 +1,120 @@
+/* eslint-disable global-require */
+
+/* eslint-disable no-throw-literal */
+import '@babel/polyfill';
+import {
+  errorObject,
+  ERROR_LOGIN,
+  ERROR_SERVER,
+  ERROR_REQUEST,
+  ERROR_COOKIE,
+} from '../../errors/errors';
+
+beforeEach(() => {
+  jest.resetModules();
+  jest.dontMock('axios');
+});
+
+test('should return a cookie', async () => {
+  jest.doMock('axios', () => jest.fn(() => ({ headers: { 'set-cookie': ['cookie; path'] } })));
+  const { login } = require('../../requests');
+  const cookie = await login();
+  expect(cookie).toBe('cookie');
+});
+
+test('should throw an unauthorized error', async () => {
+  jest.doMock('axios', () =>
+    jest.fn(() => {
+      throw { response: { status: 401 } };
+    })
+  );
+  let errorCatcher;
+  try {
+    const { login } = require('../../requests');
+    await login();
+  } catch (error) {
+    errorCatcher = error;
+  }
+
+  expect(errorCatcher).toEqual(errorObject(ERROR_LOGIN, 'Login'));
+});
+
+test('should throw a server error', async () => {
+  jest.doMock('axios', () =>
+    jest.fn(() => {
+      throw { response: { status: 500 } };
+    })
+  );
+  let errorCatcher;
+  try {
+    const { login } = require('../../requests');
+    await login();
+  } catch (error) {
+    errorCatcher = error;
+  }
+  expect(errorCatcher).toEqual(errorObject(ERROR_SERVER, 'Login'));
+});
+
+test('should throw a request error', async () => {
+  jest.doMock('axios', () =>
+    jest.fn(() => {
+      throw { request: {} };
+    })
+  );
+  let errorCatcher;
+  try {
+    const { login } = require('../../requests');
+    await login();
+  } catch (error) {
+    errorCatcher = error;
+  }
+  expect(errorCatcher).toEqual(errorObject(ERROR_REQUEST, 'Login'));
+});
+
+test('should throw a cookie error', async () => {
+  jest.doMock('axios', () =>
+    jest.fn(() => {
+      return { headers: {} };
+    })
+  );
+  let errorCatcher;
+  try {
+    const { login } = require('../../requests');
+    await login();
+  } catch (error) {
+    errorCatcher = error;
+  }
+  expect(errorCatcher).toEqual(errorObject(ERROR_COOKIE, 'Login'));
+});
+
+test('should also throw a cookie error', async () => {
+  jest.doMock('axios', () =>
+    jest.fn(() => {
+      return { headers: { set: '' } };
+    })
+  );
+  let errorCatcher;
+  try {
+    const { login } = require('../../requests');
+    await login();
+  } catch (error) {
+    errorCatcher = error;
+  }
+  expect(errorCatcher).toEqual(errorObject(ERROR_COOKIE, 'Login'));
+});
+
+test('should throw an unknown error', async () => {
+  jest.doMock('axios', () =>
+    jest.fn(() => {
+      return { response: { status: 'unknown' } };
+    })
+  );
+  let errorCatcher;
+  try {
+    const { login } = require('../../requests');
+    await login();
+  } catch (error) {
+    errorCatcher = error;
+  }
+  expect(errorCatcher).toEqual(errorObject(ERROR_COOKIE, 'Login'));
+});

--- a/src/tests/validation/facilitiesValidation.test.js
+++ b/src/tests/validation/facilitiesValidation.test.js
@@ -1,6 +1,8 @@
 import { errorObject, ERROR_VALIDATION } from '../../errors/errors';
 import { facilitiesValidation } from '../../validation';
 
+// TODO: Potentially make a file for 'Test data' for
+// testing objects etc.
 test('should return four', () => {
   const testingObject = [
     {

--- a/src/tests/validation/facilitiesValidation.test.js
+++ b/src/tests/validation/facilitiesValidation.test.js
@@ -1,4 +1,4 @@
-import errorObject from '../../errors/errors';
+import { errorObject, ERROR_VALIDATION } from '../../errors/errors';
 import { facilitiesValidation } from '../../validation';
 
 test('should return four', () => {
@@ -50,7 +50,7 @@ test('should throw on code missing', () => {
   } catch (e) {
     errorCatcher = e;
   }
-  expect(errorCatcher).toEqual(errorObject('Unfound facility'));
+  expect(errorCatcher).toEqual(errorObject(ERROR_VALIDATION, 'facilitiesValidation', 'facility'));
 });
 
 test('should throw on non array or empty object', () => {
@@ -62,5 +62,5 @@ test('should throw on non array or empty object', () => {
   } catch (e) {
     errorCatcher = e;
   }
-  expect(errorCatcher).toEqual(errorObject('Unfound facility'));
+  expect(errorCatcher).toEqual(errorObject(ERROR_VALIDATION, 'facilitiesValidation', 'facility'));
 });

--- a/src/tests/validation/parameterValidation.test.js
+++ b/src/tests/validation/parameterValidation.test.js
@@ -1,5 +1,5 @@
 import { parameterValidation } from '../../validation';
-import errorObject from '../../errors/errors';
+import { errorObject, ERROR_VALIDATION } from '../../errors/errors';
 
 test('should return true', () => {
   expect(parameterValidation({ requisition: {}, requisitionLines: [], regimeLines: [] })).toBe(
@@ -16,16 +16,16 @@ test('should throw when fields are not correct data types', () => {
   } catch (e) {
     errorCatcher = e;
   }
-  expect(errorCatcher).toEqual(errorObject('Parameter validation failed'));
+  expect(errorCatcher).toEqual(errorObject(ERROR_VALIDATION, 'parameterValidation', 'lines'));
   errorCatcher = null;
 
   // Requisition should be an object.
   try {
-    parameterValidation({ requisition: [], requisitionLines: [], regimeLines: {} });
+    parameterValidation({ requisition: [], requisitionLines: [], regimeLines: [] });
   } catch (e) {
     errorCatcher = e;
   }
-  expect(errorCatcher).toEqual(errorObject('Parameter validation failed'));
+  expect(errorCatcher).toEqual(errorObject(ERROR_VALIDATION, 'parameterValidation', 'requisition'));
 });
 
 test('should throw when parameter is not an object', () => {
@@ -35,7 +35,7 @@ test('should throw when parameter is not an object', () => {
   } catch (e) {
     errorCatcher = e;
   }
-  expect(errorCatcher).toEqual(errorObject('Parameter validation failed'));
+  expect(errorCatcher).toEqual(errorObject(ERROR_VALIDATION, 'parameterValidation', 'lines'));
 });
 
 test('should throw when fields not present', () => {
@@ -47,7 +47,7 @@ test('should throw when fields not present', () => {
   } catch (e) {
     errorCatcher = e;
   }
-  expect(errorCatcher).toEqual(errorObject('Parameter validation failed'));
+  expect(errorCatcher).toEqual(errorObject(ERROR_VALIDATION, 'parameterValidation', 'lines'));
   errorCatcher = null;
 
   // Requires a requisition field.
@@ -56,5 +56,5 @@ test('should throw when fields not present', () => {
   } catch (e) {
     errorCatcher = e;
   }
-  expect(errorCatcher).toEqual(errorObject('Parameter validation failed'));
+  expect(errorCatcher).toEqual(errorObject(ERROR_VALIDATION, 'parameterValidation', 'requisition'));
 });

--- a/src/tests/validation/programValidation.test.js
+++ b/src/tests/validation/programValidation.test.js
@@ -1,5 +1,5 @@
 import { programValidation } from '../../validation';
-import errorObject from '../../errors/errors';
+import { ERROR_VALIDATION, errorObject } from '../../errors/errors';
 
 test('should return id when code matches', () => {
   const testingObject = [
@@ -27,7 +27,7 @@ test('should throw on unmatched code', () => {
   } catch (e) {
     errorCatcher = e;
   }
-  expect(errorCatcher).toEqual(errorObject('Could not find the Program'));
+  expect(errorCatcher).toEqual(errorObject(ERROR_VALIDATION, 'programValidation', 'program'));
 });
 
 test('should throw on empty array', () => {
@@ -40,5 +40,5 @@ test('should throw on empty array', () => {
   } catch (e) {
     errorCatcher = e;
   }
-  expect(errorCatcher).toEqual(errorObject('Could not find the Program'));
+  expect(errorCatcher).toEqual(errorObject(ERROR_VALIDATION, 'programValidation', 'program'));
 });

--- a/src/tests/validation/programValidation.test.js
+++ b/src/tests/validation/programValidation.test.js
@@ -1,6 +1,9 @@
 import { programValidation } from '../../validation';
 import { ERROR_VALIDATION, errorObject } from '../../errors/errors';
 
+// TODO: Potentially make a file for 'Test data' for
+// testing objects etc.
+
 test('should return id when code matches', () => {
   const testingObject = [
     { id: 1, code: 'a' },

--- a/src/validation.js
+++ b/src/validation.js
@@ -1,5 +1,19 @@
 import { errorObject, ERROR_VALIDATION } from './errors/errors';
 
+// TODO: Validation the incorrect term? Some methods also return IDs etc
+// TODO: Some methods can be made more generic, will keep as is for initial
+// development, but need to check this before merging into master.
+
+/**
+ * Validates the incoming parameters. These may need to be refactored
+ * or at least renamed if each method (Login, getPrograms etc.) within
+ * the module are made to be called individually as well as as being
+ * a more specific 'bulk pusher' into eSigl.
+ * @param  {Object} inputParameters {
+ * requisition: {}, requisitionLines: [], regimeLines: []
+ * }
+ * @return {bool}   true on validation, will throw an error otherwise.
+ */
 export function parameterValidation(inputParameters) {
   const { requisition, requisitionLines, regimeLines } = inputParameters;
 
@@ -12,6 +26,14 @@ export function parameterValidation(inputParameters) {
   return true;
 }
 
+/**
+ * Validates the response from a facilities request to eSigl, ensuring
+ * the facilityCode passed from mSupply has a corresponding match
+ * in the facilities passed from eSigl. Returns the matched facility ID.
+ * @param  {String} facilityCode    facility code for the requisition to push.
+ * @param  {Array}  facilitiesList  list of facilities available to push to.
+ * @return {number} the ID for the matched facility code.
+ */
 export function facilitiesValidation(facilityCode, facilitiesList) {
   try {
     const { id: facilityId } = facilitiesList.find(facility => {
@@ -24,6 +46,14 @@ export function facilitiesValidation(facilityCode, facilitiesList) {
   }
 }
 
+/**
+ * Validates the response from a programs request to eSigl, ensuring
+ * the programCode passed from mSupply has a corresponding match
+ * in the facilities passed from eSigl. Returns the matched program ID.
+ * @param  {String}  programCode program code for the requisition to push.
+ * @param  {Array}   programList list of programs available to push to.
+ * @return {number}  The ID for the matched program code.
+ */
 export function programValidation(programCode, programList) {
   try {
     const { id: programId } = programList.find(program => {

--- a/src/validation.js
+++ b/src/validation.js
@@ -1,13 +1,13 @@
-import errorObject from './errors/errors';
+import { errorObject, ERROR_VALIDATION } from './errors/errors';
 
 export function parameterValidation(inputParameters) {
   const { requisition, requisitionLines, regimeLines } = inputParameters;
 
   if (!(Array.isArray(requisitionLines) && Array.isArray(regimeLines))) {
-    throw errorObject('Parameter validation failed');
+    throw errorObject(ERROR_VALIDATION, 'parameterValidation', 'lines');
   }
-  if (!(typeof requisition === 'object' && !Array.isArray(requisition))) {
-    throw errorObject('Parameter validation failed');
+  if ((typeof requisition === 'object' && Array.isArray(requisition)) || !requisition) {
+    throw errorObject(ERROR_VALIDATION, 'parameterValidation', 'requisition');
   }
   return true;
 }
@@ -20,7 +20,7 @@ export function facilitiesValidation(facilityCode, facilitiesList) {
     });
     return facilityId;
   } catch (e) {
-    throw errorObject('Unfound facility');
+    throw errorObject(ERROR_VALIDATION, 'facilitiesValidation', 'facility');
   }
 }
 
@@ -32,6 +32,6 @@ export function programValidation(programCode, programList) {
     });
     return programId;
   } catch (e) {
-    throw errorObject('Could not find the Program');
+    throw errorObject(ERROR_VALIDATION, 'programValidation', 'program');
   }
 }


### PR DESCRIPTION
Fixes #18 

This PR adds the Login function and `ApiConfig` class. Chose to use a class which will have `Axios` configs for each request as members. Mainly for the convenience and simplicity of having a standard interface. This makes handling of the authentication cookie easier also.

Have found that eSigl will redirect requests to `/j_security_check`, resulting in a received `JSESSIONID` and incorrect body in the response. Have stopped the redirect, which results in the correct `JSESSIONID` cookie being retrieved, as well as a `302` status code. Needed to also set `302` as a valid response within the `loginConfig`.

Have also added some error codes.

Would definitely appreciate thoughts on the axios wrapper, errors and additional tests to add.

Dependencies added in this PR:
- qs : querystring for easy request parameters. Reliable package with 18m downloads / week - https://www.npmjs.com/package/qs
- axios : Other than using http dependency, other choices include node-fetch or request. All are similar size. Axios has the lowest number of downloads @ 3.5m (others are 7m & 13m respectively). I prefer axios because of the additional configuration options. EG valid status codes, transform functions, simple approach to adding params and default or responses being parsed to JSON. Am bias as I have used it before and definitely open to hearing about the other packages (Fetch Standard is not a part of Node).
- babel-polyfil : This enables transpiling for jest as babel-node wouldn't be used.
- babel class properties : used in the ApiConfig static class.

