### PR TITLE
#50 incorrect facilities endpoint

### DIFF
--- a/src/api/ApiConfigs.js
+++ b/src/api/ApiConfigs.js
@@ -30,10 +30,10 @@ export default class ApiConfigs {
     headers: { Cookie: cookie },
   });
 
-  static getFacilitiesConfig = ({ baseURL, cookie }) => ({
+  static getFacilitiesConfig = ({ baseURL, cookie, programId }) => ({
     ...ApiConfigs.BASE_CONFIG,
     baseURL,
-    url: '/user/facilities.json',
+    url: `/create/requisition/supervised/${programId}/facilities.json`,
     headers: { Cookie: cookie },
   });
 

--- a/src/requests.js
+++ b/src/requests.js
@@ -86,11 +86,11 @@ export async function programs({ baseURL, cookie }) {
  *
  * @return {Array}  Array of facility objects.
  */
-export async function facilities({ baseURL, cookie }) {
-  const config = ApiConfigs.getFacilitiesConfig({ baseURL, cookie });
+export async function facilities({ baseURL, cookie, programId }) {
+  const config = ApiConfigs.getFacilitiesConfig({ baseURL, cookie, programId });
   try {
     const { data } = await axios(config);
-    const { facilityList } = data;
+    const { facilities: facilityList } = data;
     return facilityList;
   } catch (error) {
     const { response, request } = error;

--- a/src/tests/apiConfigs.test.js
+++ b/src/tests/apiConfigs.test.js
@@ -30,8 +30,10 @@ test('Facilities config fields should be equal', () => {
   const config = ApiConfigs.getFacilitiesConfig({
     baseURL: 'url',
     cookie: 'cookie',
+    programId: 1,
   });
   expect(config.baseURL).toBe('url');
+  expect(config.url).toBe(`/create/requisition/supervised/1/facilities.json`);
   expect(config.headers).toEqual({ Cookie: 'cookie' });
 });
 

--- a/src/tests/requests/facilities.test.js
+++ b/src/tests/requests/facilities.test.js
@@ -8,9 +8,9 @@ beforeEach(() => {
 test('should return the facilityList from response', async () => {
   jest.doMock('axios', () =>
     jest.fn(() => {
-      return { data: { facilityList: [] } };
+      return { data: { facilities: [] } };
     })
   );
   const { facilities } = require('../../requests');
-  expect(await facilities({ cookie: '', baseURL: '' })).toEqual([]);
+  expect(await facilities({ cookie: '', baseURL: '', programId: 1 })).toEqual([]);
 });


### PR DESCRIPTION
Fixes #50 

- Adds updates to facilities tests
- Updates the config to use the new endpoint
- updates the facilities function to handle the new endpoint & use a programId parameter.

Tests passing.