### PR TITLE
#51 create requisition return value

### DIFF
--- a/src/requests.js
+++ b/src/requests.js
@@ -303,9 +303,8 @@ export async function createRequisition({
   });
   try {
     const { data } = await axios(config);
-    const { Rnr } = data;
-    const { Id } = Rnr;
-    return Id;
+    const { rnr } = data;
+    return rnr;
   } catch (error) {
     const { response, request } = error;
     if (response) {

--- a/src/tests/requests/createRequisition.test.js
+++ b/src/tests/requests/createRequisition.test.js
@@ -6,7 +6,7 @@ beforeEach(() => {
 });
 
 test('should return true from response', async () => {
-  jest.doMock('axios', () => jest.fn(() => ({ data: { Rnr: { Id: 1 } } })));
+  jest.doMock('axios', () => jest.fn(() => ({ data: { rnr: { id: 1 } } })));
   const { createRequisition } = require('../../requests');
   expect(
     await createRequisition({
@@ -17,5 +17,5 @@ test('should return true from response', async () => {
       facilityId: 1,
       programId: 1,
     })
-  ).toEqual(1);
+  ).toEqual({ id: 1 });
 });


### PR DESCRIPTION
Fixes #51 

- Updated both create requisition return value (to be rnr object returned by the eSIGL server, rather than just the ID) and also the accompanying tests

Tests passing.