### PR TITLE
#107 method for initiated requisition

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmsupply/elmis-service",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "description": "Module for integration mSupply with eSigl",
   "main": "build/index.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmsupply/elmis-service",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "description": "Module for integration mSupply with eSigl",
   "main": "build/index.js",
   "directories": {

--- a/src/integrate.js
+++ b/src/integrate.js
@@ -1,5 +1,4 @@
 /* eslint-disable no-ex-assign */
-/* eslint-disable import/prefer-default-export */
 import {
   integrationValidation,
   programValidation,
@@ -91,6 +90,54 @@ export async function integrate(inputParameters) {
       }
     }
 
+    throw error;
+  }
+}
+
+export async function initiateRequisiton(inputParameters) {
+  let requisitionHasBeenCreated = false;
+  let parameterObject;
+  try {
+    // Validate input parameters - if invalid an error is thrown.
+    integrationValidation(inputParameters);
+    // Fetch and validate the parameters for the to-be-created requisition.
+    parameterObject = await createParameterObject(inputParameters);
+    // Create a requisition on the eSIGL server
+    const { requisition: outgoingRequisition } = await createRequisition(parameterObject);
+    // Flag to determine if deletion should occur if any errors are thrown from this point
+    // to avoid having the requisition be in an inconsistent/unknown state.
+    requisitionHasBeenCreated = true;
+    const { requisition } = inputParameters;
+    // Add the ID of the requisition in the eSIGL database and merge the eSIGL requisition
+    // with the incoming requisition that is being created.
+    parameterObject = {
+      ...parameterObject,
+      requisitionId: outgoingRequisition.id,
+      ...(await requisitionMerge(requisition, outgoingRequisition)),
+    };
+    // Update the requisition which has been created on the eSIGL server with values from
+    // the incoming requisition.
+    await updateRequisition(parameterObject);
+    return {
+      requisitionId: parameterObject.requisitionId,
+      unmatchedIncomingLines: parameterObject.unmatchedIncomingLines,
+      unmatchedOutgoingLines: parameterObject.unmatchedOutgoingLines,
+    };
+  } catch (error) {
+    // If the error caught has no code, it has not been explicitly thrown
+    // and is an unkown runtime error.
+    if (!error.code) error = errorObject(ERROR_RUNTIME, error.message);
+    // Otherwise, the error has been explicitly thrown - determine if a
+    // requisition has already been created so we can attempt to delete it.
+    if (requisitionHasBeenCreated) {
+      try {
+        await deleteRequisition(parameterObject);
+        error.wasDeleted = true;
+      } catch (deleteError) {
+        error.wasDeleted = false;
+        error.deleteError = deleteError;
+      }
+    }
     throw error;
   }
 }


### PR DESCRIPTION
Fixes #107 

Pretty much copied from the other `integrate` method. Could refactor to have less duplication but I like having the explicit methods for 4D to call. 

Have tested and created requisitions on eSIGL, will write jest tests in a new issue

This also bumps the version