### PR TITLE
#124 fix node version runtime error

### DIFF
--- a/src/requisitionMerge.js
+++ b/src/requisitionMerge.js
@@ -78,7 +78,7 @@ const createRegimenLineItems = regimenData => {
       });
       return indicatorRegimenLineItems;
     })
-    .reduce((acc, indicatorRegimenLineItems) => [...acc, ...indicatorRegimenLineItems]);
+    .reduce((acc, indicatorRegimenLineItems) => [...acc, ...indicatorRegimenLineItems], []);
   return regimenLineItems;
 };
 

--- a/src/requisitionMerge.js
+++ b/src/requisitionMerge.js
@@ -78,7 +78,7 @@ const createRegimenLineItems = regimenData => {
       });
       return indicatorRegimenLineItems;
     })
-    .flat();
+    .reduce((acc, indicatorRegimenLineItems) => [...acc, ...indicatorRegimenLineItems]);
   return regimenLineItems;
 };
 


### PR DESCRIPTION
Fixes #124.

Error was thrown by `.flat()`, refactored to use `.reduce()`.

All tests passing.