### PR TITLE
remove beginningBalance

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmsupply/elmis-service",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Module for integration mSupply with eSigl",
   "main": "build/index.js",
   "directories": {

--- a/src/requisitionMerge.js
+++ b/src/requisitionMerge.js
@@ -18,7 +18,6 @@ const MERGE_FIELDS_MAPPING = {
   quantityRequested: 'Cust_stock_order',
   quantityDispensed: 'outgoingStock',
   stockInHand: 'stock_on_hand',
-  beginningBalance: 'stock_on_hand',
   previousStockInHand: 'stock_on_hand',
   totalLossesAndAdjustments: 'inventoryAdjustments',
 };


### PR DESCRIPTION
Removes the `beginningBalance` value.
Tested and working as expected:

<img width="1076" alt="Screen Shot 2020-08-26 at 11 57 26 AM" src="https://user-images.githubusercontent.com/9192912/91239429-98eb7d00-e793-11ea-8783-8fe3eeb7ecc0.png">

![Screen Shot 2020-08-26 at 11 57 39 AM](https://user-images.githubusercontent.com/9192912/91239432-9ab54080-e793-11ea-9624-398301e903be.png)
