### PR TITLE
Add adjustments

### DIFF
--- a/src/api/ApiConfigs.js
+++ b/src/api/ApiConfigs.js
@@ -27,7 +27,7 @@ export default class ApiConfigs {
   static getProgramsConfig = ({ baseURL, cookie }) => ({
     ...ApiConfigs.BASE_CONFIG,
     baseURL,
-    url: '/create/requisition/programs',
+    url: '/create/requisition/programs.json',
     headers: { Cookie: cookie },
   });
 


### PR DESCRIPTION
Fixes #177 

This checks the `beginningBalance` value, and calculates any adjustments that may be required to let the mSupply SoH value be supplied.

Internal order in mSupply:
<img width="1061" alt="Screen Shot 2022-06-01 at 2 58 27 PM" src="https://user-images.githubusercontent.com/9192912/171324065-c49bdf6c-8195-4c87-b3f3-bb6bfa8669f6.png">
<img width="1063" alt="Screen Shot 2022-06-01 at 2 58 34 PM" src="https://user-images.githubusercontent.com/9192912/171324073-a3b10143-4509-42e0-8465-fef04c1c59c3.png">

And the [resulting requisition](https://esigltest.npsp.ci/public/pages/logistics/rnr/index.html#/create-rnr/192609/1663/25?supplyType=fullSupply&page=1)
![Screen Shot 2022-06-01 at 2 58 07 PM](https://user-images.githubusercontent.com/9192912/171324081-95ac6e52-3a18-46aa-abd4-ac176c2a70c4.png)
![Screen Shot 2022-06-01 at 2 58 13 PM](https://user-images.githubusercontent.com/9192912/171324087-cbb2cc05-a0fb-48f9-bf1e-34abbbbc8778.png)

