### PR TITLE
zero quantity message

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,10 @@
 {
   "presets": [["@babel/preset-env", { "shippedProposals": true }]],
-  "plugins": ["@babel/plugin-proposal-class-properties"]
+  "plugins": ["@babel/plugin-proposal-class-properties"],
+  "env": {
+    "development": {
+      "sourceMaps": "inline",
+      "retainLines": true
+    }
+  }
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,19 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Debug",
+      "program": "${workspaceFolder}/src/index.js",
+      "runtimeExecutable": "${workspaceFolder}/node_modules/.bin/babel-node",
+      "runtimeArgs": ["--nolazy"],
+      "env": {
+        "BABEL_ENV": "development"
+      }
+    }
+  ]
+}

--- a/src/requisitionMerge.js
+++ b/src/requisitionMerge.js
@@ -117,8 +117,8 @@ const minimalOutgoingLine = outgoingLine => ({
  * @return {string}
  */
 const getNewReason = incomingLine => {
-  const { options } = incomingLine;
-  let newReason = 'mSupply: Unknown Reason';
+  const { options, Cust_stock_issued } = incomingLine;
+  let newReason = !Cust_stock_issued ? 'MSupply: Zero quantity ordered' : 'mSupply: Unknown Reason';
   if (options && options.title) newReason = options.title;
   return newReason;
 };
@@ -238,7 +238,7 @@ const getMappedFields = incomingLine => {
 
 const findMatchedRequisition = ({ code: incomingItemCode }) => ({
   productCode: outgoingItemCode,
-}) => outgoingItemCode === incomingItemCode;
+}) => outgoingItemCode.trim() === incomingItemCode.trim();
 
 /**
  * Merges an array of incoming regimen lines with outgoing regimen lines.


### PR DESCRIPTION
Fixes #196 

The issue with the adjustment is simply that the eSIGL instance had an item code with a space at the end, so we didn't match correctly. I've trimmed the codes before matching.

Have forced a message of `mSupply: Zero quantity ordered` when the quantity is `0`